### PR TITLE
Write to stdout on '-' for svg

### DIFF
--- a/bin/wavedrom-cli.js
+++ b/bin/wavedrom-cli.js
@@ -2582,7 +2582,13 @@ try {
     if (typeof argv.s === 'string') {
         svgFileName = argv.s;
         svgFileContent = report.svg;
-        fs.write(svgFileName, svgFileContent, 'w');
+        if (argv.s === '-') {
+            // Write to stdout
+            system.stdout.write(svgFileContent);
+        } else {
+            // Write to file
+            fs.write(svgFileName, svgFileContent, 'w');
+        }
     }
 
     if (typeof argv.p === 'string') {


### PR DESCRIPTION
I would do PNG too, but my javascript and knowledge of phantomjs isn't good enough. There seems to be a renderBase64() function, but when passing that through atob() and then to system.stdout.write() that doesn't generate a correct PNG. It looks to be some form of weird encoding issue as just writing the result of renderBase64() and then decoding it on the command line (base64 -D on my mac) does produce a valid png.